### PR TITLE
Fix workflow file

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 env:
   REGISTRY: "innocotravel"
@@ -65,5 +62,4 @@ jobs:
             docker compose pull
             docker compose up -d
 
-            cd db_migration
             ./migrate_up.sh


### PR DESCRIPTION
Currently, workflow start on pull requests is undesirable (our server is overwritten with changes that are not yet on master) and it might be unsafe (does PR from a fork also see our secrets? I'm not sure). Additionally, our migration script has moved to the main folder, so `cd` is no longer needed.